### PR TITLE
Fix display with short events

### DIFF
--- a/calendar-card.js
+++ b/calendar-card.js
@@ -461,6 +461,7 @@ var Ce=function(e,t){var n=e.startNode.parentNode,a=void 0===t?e.endNode:t.start
     table {
         border-spacing: 0;
         margin-bottom: 10px;
+        width: 100%;
     }
 
     .day-wrapper td {


### PR DESCRIPTION
Before:
<img width="396" alt="Screenshot 2019-05-28 at 13 47 45" src="https://user-images.githubusercontent.com/1885159/58475795-34381180-814f-11e9-9b27-551ffc4fe62a.png">

After:
<img width="393" alt="Screenshot 2019-05-28 at 13 48 40" src="https://user-images.githubusercontent.com/1885159/58475836-5336a380-814f-11e9-86fe-3c22437895c6.png">