### PR TITLE
Modified to use uid as well as id when filtering for unique events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ class CalendarCard extends LitElement {
   processEvents() {
     // for some reason Lit Element is trying to sync multiple times before this is complete causing
     // duplicate events - this forces unique events only by looking at calendar event id
-    const uniqueEvents = this._allEvents.filter((event, index, self) => index === self.findIndex(e => e.id === event.id));
+    const uniqueEvents = this._allEvents.filter((event, index, self) => index === self.findIndex(e => ((e.id === event.id) && (e.uid === event.uid))));
 
     // convert each calendar object to a UI event
     let newEvents = uniqueEvents.reduce((events, event) => {


### PR DESCRIPTION
This appears to finish fixing #37.