### PR TITLE
Use secondary text color for location

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -59,7 +59,7 @@ const style = css`
 
     .day-wrapper .overview .time,
     .day-wrapper .location ha-icon {
-        color: var(--primary-color);
+        color: var(--secondary-text-color);
     }
 
     .day-wrapper hr.progress-bar {


### PR DESCRIPTION
`--primary-color` isn't necessarily good for text, especially on dark themes. Using `--secondary-text-color` instead seems like a nice way to not get in the way of theming.

Default theme:
Before:
<img width="192" alt="Screenshot 2019-08-16 at 16 50 19" src="https://user-images.githubusercontent.com/1885159/63176288-f4920f00-c045-11e9-8e1d-34a057e9de98.png">

After:
<img width="179" alt="Screenshot 2019-08-16 at 16 49 36" src="https://user-images.githubusercontent.com/1885159/63176250-e3490280-c045-11e9-9fa5-6c36e3743625.png">

[synthwave theme](https://github.com/bbbenji/synthwave-hass)
Before:
<img width="183" alt="Screenshot 2019-08-16 at 16 51 09" src="https://user-images.githubusercontent.com/1885159/63176346-1390a100-c046-11e9-8540-eb6c9c816ba5.png">

After:
<img width="180" alt="Screenshot 2019-08-16 at 16 51 51" src="https://user-images.githubusercontent.com/1885159/63176420-2c995200-c046-11e9-80ad-2f2993e1ad1b.png">