### PR TITLE
More subtle progress bar dot & better aligned

### DIFF
--- a/dist/calendar-card.js
+++ b/dist/calendar-card.js
@@ -755,8 +755,9 @@ var ze=function(e,t){var a=e.startNode.parentNode,n=void 0===t?e.endNode:t.start
     }
 
     .day-wrapper ha-icon.progress-bar {
-        height: 12px;
-        width: 12px;
+        height: 9px;
+        width: 9px;
+        margin-top: 2px;
         color: var(--accent-color);
     }
 


### PR DESCRIPTION
The dot of the progress bar was very big and misaligned. I made it a little bit smaller and aligned it correctly.

Before:
![calendar_card](https://user-images.githubusercontent.com/30938717/63223981-f848a180-c1bd-11e9-9510-16f62a2c22d6.PNG)
After:
![calendar_card2](https://user-images.githubusercontent.com/30938717/63223980-f7b00b00-c1bd-11e9-88f5-de576cceeaf4.PNG)

This is only the change of the progress bar. The changes of event origin are in the other pull request.