### PR TITLE
Log error for failing calendar

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -176,13 +176,17 @@ class CalendarCard extends LitElement {
       const calendarEntity = (entity && entity.entity) || entity;
       const url = `calendars/${calendarEntity}?start=${start}Z&end=${end}Z`;
 
-      const events = (await this.__hass.callApi('get', url))
-      .map(event => {
-        event.entity = entity;
-        return event;
-      });
+      try{
+        const events = (await this.__hass.callApi('get', url))
+        .map(event => {
+          event.entity = entity;
+          return event;
+        });
 
-      this._allEvents.push(...events);
+        this._allEvents.push(...events);
+      }catch(err){
+        throw new Error(`Couldn't load ${calendarEntity}: ${err.error}`);
+      };
     }
 
     return this.processEvents();


### PR DESCRIPTION
One of my calendars broke at some point (no clue why). It took me forever to realize what was wrong because the only thing logged to my Firefox console was "TypeError: Object". This patch improves the error message so that users can actually find out what is wrong (example: Error: Couldn't load calendar.work: Response error: 400).

I want to see if I can at some point figure out how to show the error message IN the card and continue loading all the other events from other calendars, but for now, this is at very least an improvement over the current situation.