### PR TITLE
Improved performance and error handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,18 @@ class CalendarCard extends LitElement {
     const events = await this.getAllEvents();
     const groupedEventsByDay = this.groupEventsByDay(events);
 
+    // get all failed calendar retrievals
+    const failedCalendars = this._failedEntities.reduce((errorTemplate, failedEntity) => {
+      return html`
+        ${errorTemplate}
+        <tr>
+          <td class="failed-name">${failedEntity.name}</td>
+          <td class="failed-error">${failedEntity.error.error}</td>
+          <td class="failed-icon"><ha-icon icon="mdi:alert-circle-outline"></ha-icon></td>
+        </tr>
+      `;
+    }, html``);
+
     // get today to see what events are today
     const today = moment(new Date());
 
@@ -149,6 +161,7 @@ class CalendarCard extends LitElement {
     this.events = html`
       <table>
         <tbody>
+          ${failedCalendars}
           ${calendar}
         </tbody>
       </table>
@@ -191,7 +204,7 @@ class CalendarCard extends LitElement {
         })
         .catch(error => {
           this._failedEntities.push({
-            entity: calendarEntity,
+            name: this.config.entities.find(entity => entity.entity === calendarEntity).name || calendarEntity,
             error
           });
         }));


### PR DESCRIPTION
This improves the performance of loading calendar events by making concurrent requests instead of serially waiting for them.
Handling errors so a single request failure wont break the card.

Also, thanks to @TheLastProject, it shows which entities it failed to load events from:
![photo_2019-10-04_23-01-42](https://user-images.githubusercontent.com/1885159/66239743-fb123e00-e6fa-11e9-8f30-95baeb319db9.jpg)
