### PR TITLE
Added new option to pull link url from the source property

### DIFF
--- a/src/calendar-event.js
+++ b/src/calendar-event.js
@@ -135,6 +135,14 @@ export default class CalendarEvent {
     }
 
     /**
+     * get the URL from the source element
+     * @return {String}
+     */
+    get sourceUrl() {
+        return (this.rawEvent.source) ? this.rawEvent.source.url || '' : '';
+    }
+
+    /**
      * is a multiday event (not all day)
      * @return {Boolean}
      */

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -24,6 +24,7 @@ export default {
     hideDeclined: false,
     notifyEntity: null,
     disableLinks: false,
+    useSourceUrl: false,
     notifyDateTimeFormat: 'MM/DD/YYYY HH:mma',
     fullDayEventText: 'All day',
     startText: 'Start',

--- a/src/index.js
+++ b/src/index.js
@@ -145,14 +145,17 @@ class CalendarCard extends LitElement {
         const eventDateTime = moment(eventDay.day);
         const todayKls = this.config.highlightToday && eventDateTime.isSame(today, "day") ? 'highlight-events' : '';
 
-        const disableLink = this.config.disableLinks || !event.htmlLink;
+        // use the source element url if it exists
+        const linkUrl = this.config.useSourceUrl && event.sourceUrl ? event.sourceUrl : event.htmlLink;
         
+        const disableLink = this.config.disableLinks || !linkUrl;
+
           return html`
             <tr class='day-wrapper ${lastKls} ${todayKls}'>
               <td class="${isLastEventInGroup ? '' : 'date'}">
                 ${getDateHtml(index, eventDateTime, this.config)}
               </td>
-              <td class="overview ${disableLink ? 'no-pointer' : ''}" @click=${e => openLink(e, event.htmlLink, this.config)}>
+              <td class="overview ${disableLink ? 'no-pointer' : ''}" @click=${e => openLink(e, linkUrl, this.config)}>
                 <div class="title">${event.title}</div>
                 ${getTimeHtml(event, this.config)}
                 ${getEventOrigin(event, this.config)}


### PR DESCRIPTION
Small feature addition to utilize the url from the source property of the event. This let's you launch custom URLs from the calendar card rather than linking to google calendar. See Google api reference for more info: https://developers.google.com/calendar/v3/reference/events